### PR TITLE
Increasing the iteration count number

### DIFF
--- a/deepest-learning/seq2seq/Seq2Seq.py
+++ b/deepest-learning/seq2seq/Seq2Seq.py
@@ -119,7 +119,7 @@ maxDecoderLength = maxEncoderLength
 lstmUnits = 112
 embeddingDim = lstmUnits
 numLayersLSTM = 3
-numIterations = 100000
+numIterations = 100001
 
 wordList = []
 

--- a/flask-server/app.py
+++ b/flask-server/app.py
@@ -35,7 +35,7 @@ sess = tf.Session()
 sess.run(tf.global_variables_initializer())
 
 # Load in checkpoint with saved model
-saver = tf.train.import_meta_graph('models/pretrained_seq2seq.ckpt-90000.meta')
+saver = tf.train.import_meta_graph('models/pretrained_seq2seq.ckpt-100000.meta')
 saver.restore(sess, tf.train.latest_checkpoint('models'))
 zeroVector = np.zeros((1), dtype='int32')
 


### PR DESCRIPTION
Thanks for the great workshop. This might be my hobby project for a while. 
I noticed that the final trained network wasn't returning the same output that I saw in the validation phrases during training. I noticed that the final model isn't using what should be the final checkpoint at 100k iterations. By increasing the iteration count by 1, we should be able to use the full 100k iterations for the final model.